### PR TITLE
Inertial scrolling dispatch toast

### DIFF
--- a/rnote-ui/data/ui/settingspanel.ui
+++ b/rnote-ui/data/ui/settingspanel.ui
@@ -106,7 +106,8 @@
                     <child>
                       <object class="AdwActionRow" id="general_inertial_scrolling_row">
                         <property name="title" translatable="yes">Inertial Touch Scrolling</property>
-                        <property name="subtitle" translatable="yes">Set whether touch scrolling on the canvas is inertial. Always disabled if touch drawing is enabled.</property>
+                        <property name="subtitle" translatable="yes">Set whether touch scrolling on the canvas is inertial.
+An application restart is required when this option gets disabled.</property>
                         <child type="suffix">
                           <object class="GtkSwitch" id="general_inertial_scrolling_switch">
                             <property name="valign">center</property>

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -789,7 +789,7 @@ impl RnCanvas {
 
                             canvas.set_output_file(other_file.cloned());
 
-                            appwindow.overlays().dispatch_toast_text(&gettext("Opened file was renamed on disk"), 5);
+                            appwindow.overlays().dispatch_toast_text(&gettext("Opened file was renamed on disk"), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT);
                         }
                     },
                     gio::FileMonitorEvent::Deleted | gio::FileMonitorEvent::MovedOut => {
@@ -802,7 +802,7 @@ impl RnCanvas {
                         canvas.set_unsaved_changes(true);
                         canvas.set_output_file(None);
 
-                        appwindow.overlays().dispatch_toast_text(&gettext("Opened file was moved or deleted on disk"), 5);
+                        appwindow.overlays().dispatch_toast_text(&gettext("Opened file was moved or deleted on disk"), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT);
                     },
                     _ => {},
                 }

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -789,7 +789,7 @@ impl RnCanvas {
 
                             canvas.set_output_file(other_file.cloned());
 
-                            appwindow.overlays().dispatch_toast_text(&gettext("Opened file was renamed on disk"))
+                            appwindow.overlays().dispatch_toast_text(&gettext("Opened file was renamed on disk"), 5);
                         }
                     },
                     gio::FileMonitorEvent::Deleted | gio::FileMonitorEvent::MovedOut => {
@@ -802,7 +802,7 @@ impl RnCanvas {
                         canvas.set_unsaved_changes(true);
                         canvas.set_output_file(None);
 
-                        appwindow.overlays().dispatch_toast_text(&gettext("Opened file was moved or deleted on disk"));
+                        appwindow.overlays().dispatch_toast_text(&gettext("Opened file was moved or deleted on disk"), 5);
                     },
                     _ => {},
                 }

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -49,9 +49,10 @@ pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanva
 
             match canvas.save_document_to_file(&selected_file).await {
                 Ok(true) => {
-                    appwindow
-                        .overlays()
-                        .dispatch_toast_text(&gettext("Saved document successfully"), 5);
+                    appwindow.overlays().dispatch_toast_text(
+                        &gettext("Saved document successfully"),
+                        crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT,
+                    );
                 }
                 Ok(false) => {
                     // Saving was already in progress
@@ -176,7 +177,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
                                 log::error!("exporting document failed, Error: `{e:?}`");
                                 appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
                             } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document successfully"), 5);
+                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document successfully"), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT);
                             }
 
                             appwindow.overlays().finish_progressbar();
@@ -430,7 +431,7 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
                                 log::error!("exporting document pages failed, Error: `{e:?}`");
                                 appwindow.overlays().dispatch_toast_error(&gettext("Exporting document pages failed"));
                             } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document pages successfully"), 5);
+                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document pages successfully"), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT);
                             }
 
                             appwindow.overlays().finish_progressbar();
@@ -663,7 +664,7 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
                                 log::error!("exporting selection failed, Error: `{e:?}`");
                                 appwindow.overlays().dispatch_toast_error(&gettext("Exporting selection failed"));
                             } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Exported selection successfully"), 5);
+                                appwindow.overlays().dispatch_toast_text(&gettext("Exported selection successfully"), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT);
                             }
 
                             appwindow.overlays().finish_progressbar();
@@ -761,9 +762,10 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
                     .overlays()
                     .dispatch_toast_error(&gettext("Exporting engine state failed"));
             } else {
-                appwindow
-                    .overlays()
-                    .dispatch_toast_text(&gettext("Exported engine state successfully"), 5);
+                appwindow.overlays().dispatch_toast_text(
+                    &gettext("Exported engine state successfully"),
+                    crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT,
+                );
             }
 
             appwindow.overlays().finish_progressbar();
@@ -807,9 +809,10 @@ pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, ca
                     .overlays()
                     .dispatch_toast_error(&gettext("Exporting engine config failed"));
             } else {
-                appwindow
-                    .overlays()
-                    .dispatch_toast_text(&gettext("Exported engine config successfully"), 5);
+                appwindow.overlays().dispatch_toast_text(
+                    &gettext("Exported engine config successfully"),
+                    crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT,
+                );
             }
 
             appwindow.overlays().finish_progressbar();

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -51,7 +51,7 @@ pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanva
                 Ok(true) => {
                     appwindow
                         .overlays()
-                        .dispatch_toast_text(&gettext("Saved document successfully"));
+                        .dispatch_toast_text(&gettext("Saved document successfully"), 5);
                 }
                 Ok(false) => {
                     // Saving was already in progress
@@ -176,7 +176,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
                                 log::error!("exporting document failed, Error: `{e:?}`");
                                 appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
                             } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document successfully"));
+                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document successfully"), 5);
                             }
 
                             appwindow.overlays().finish_progressbar();
@@ -430,7 +430,7 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
                                 log::error!("exporting document pages failed, Error: `{e:?}`");
                                 appwindow.overlays().dispatch_toast_error(&gettext("Exporting document pages failed"));
                             } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document pages successfully"));
+                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document pages successfully"), 5);
                             }
 
                             appwindow.overlays().finish_progressbar();
@@ -663,7 +663,7 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
                                 log::error!("exporting selection failed, Error: `{e:?}`");
                                 appwindow.overlays().dispatch_toast_error(&gettext("Exporting selection failed"));
                             } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Exported selection successfully"));
+                                appwindow.overlays().dispatch_toast_text(&gettext("Exported selection successfully"), 5);
                             }
 
                             appwindow.overlays().finish_progressbar();
@@ -763,7 +763,7 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
             } else {
                 appwindow
                     .overlays()
-                    .dispatch_toast_text(&gettext("Exported engine state successfully"));
+                    .dispatch_toast_text(&gettext("Exported engine state successfully"), 5);
             }
 
             appwindow.overlays().finish_progressbar();
@@ -809,7 +809,7 @@ pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, ca
             } else {
                 appwindow
                     .overlays()
-                    .dispatch_toast_text(&gettext("Exported engine config successfully"));
+                    .dispatch_toast_text(&gettext("Exported engine config successfully"), 5);
             }
 
             appwindow.overlays().finish_progressbar();

--- a/rnote-ui/src/main.rs
+++ b/rnote-ui/src/main.rs
@@ -18,7 +18,7 @@ pub(crate) mod globals;
 pub(crate) mod groupediconpicker;
 mod iconpicker;
 mod mainheader;
-mod overlays;
+pub(crate) mod overlays;
 pub(crate) mod penssidebar;
 mod settingspanel;
 pub(crate) mod strokewidthpicker;

--- a/rnote-ui/src/overlays.rs
+++ b/rnote-ui/src/overlays.rs
@@ -94,6 +94,9 @@ mod imp {
     }
 }
 
+/// The default timeout for regular text toasts.
+pub(crate) const TEXT_TOAST_TIMEOUT_DEFAULT: u32 = 5;
+
 glib::wrapper! {
     pub(crate) struct RnOverlays(ObjectSubclass<imp::RnOverlays>)
     @extends Widget;

--- a/rnote-ui/src/overlays.rs
+++ b/rnote-ui/src/overlays.rs
@@ -432,17 +432,15 @@ impl RnOverlays {
         button_callback: F,
         timeout: u32,
     ) -> adw::Toast {
-        let text_notify_toast = adw::Toast::builder()
+        let toast = adw::Toast::builder()
             .title(text)
             .priority(adw::ToastPriority::High)
             .button_label(button_label)
             .timeout(timeout)
             .build();
-
-        text_notify_toast.connect_button_clicked(button_callback);
-        self.toast_overlay().add_toast(text_notify_toast.clone());
-
-        text_notify_toast
+        toast.connect_button_clicked(button_callback);
+        self.toast_overlay().add_toast(toast.clone());
+        toast
     }
 
     /// Ensures that only one toast per `singleton_toast` is queued at the same time by dismissing the previous toast.
@@ -460,31 +458,40 @@ impl RnOverlays {
         if let Some(previous_toast) = singleton_toast {
             previous_toast.dismiss();
         }
-
-        let text_notify_toast =
-            self.dispatch_toast_w_button(text, button_label, button_callback, timeout);
-        *singleton_toast = Some(text_notify_toast);
+        *singleton_toast =
+            Some(self.dispatch_toast_w_button(text, button_label, button_callback, timeout));
     }
 
-    pub(crate) fn dispatch_toast_text(&self, text: &str) {
-        let text_notify_toast = adw::Toast::builder()
+    pub(crate) fn dispatch_toast_text(&self, text: &str, timeout: u32) -> adw::Toast {
+        let toast = adw::Toast::builder()
             .title(text)
             .priority(adw::ToastPriority::High)
-            .timeout(5)
+            .timeout(timeout)
             .build();
-
-        self.toast_overlay().add_toast(text_notify_toast);
+        self.toast_overlay().add_toast(toast.clone());
+        toast
     }
 
-    pub(crate) fn dispatch_toast_error(&self, error: &String) {
-        let text_notify_toast = adw::Toast::builder()
-            .title(error.as_str())
+    pub(crate) fn dispatch_toast_text_singleton(
+        &self,
+        text: &str,
+        timeout: u32,
+        singleton_toast: &mut Option<adw::Toast>,
+    ) {
+        if let Some(previous_toast) = singleton_toast {
+            previous_toast.dismiss();
+        }
+        *singleton_toast = Some(self.dispatch_toast_text(text, timeout));
+    }
+
+    pub(crate) fn dispatch_toast_error(&self, error: &str) -> adw::Toast {
+        let toast = adw::Toast::builder()
+            .title(error)
             .priority(adw::ToastPriority::High)
             .timeout(0)
             .build();
-
+        self.toast_overlay().add_toast(toast.clone());
         log::error!("{error}");
-
-        self.toast_overlay().add_toast(text_notify_toast);
+        toast
     }
 }

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -545,7 +545,7 @@ impl RnSettingsPanel {
             clone!(@weak self as settingspanel, @weak appwindow => move |switch| {
                 if !switch.is_active() {
                     appwindow.overlays().dispatch_toast_text_singleton(
-                        &gettext("The app needs to be restarted."),
+                        &gettext("The application needs to be restarted."),
                         0,
                         &mut settingspanel.imp().app_restart_toast_singleton.borrow_mut()
                     );

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -545,7 +545,7 @@ impl RnSettingsPanel {
             clone!(@weak self as settingspanel, @weak appwindow => move |switch| {
                 if !switch.is_active() {
                     appwindow.overlays().dispatch_toast_text_singleton(
-                        &gettext("The application needs to be restarted."),
+                        &gettext("Application restart is required"),
                         0,
                         &mut settingspanel.imp().app_restart_toast_singleton.borrow_mut()
                     );

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -29,6 +29,7 @@ mod imp {
     #[template(resource = "/com/github/flxzt/rnote/ui/settingspanel.ui")]
     pub(crate) struct RnSettingsPanel {
         pub(crate) temporary_format: Rc<RefCell<Format>>,
+        pub(crate) app_restart_toast_singleton: RefCell<Option<adw::Toast>>,
 
         #[template_child]
         pub(crate) settings_scroller: TemplateChild<ScrolledWindow>,
@@ -539,6 +540,18 @@ impl RnSettingsPanel {
             )
             .sync_create()
             .build();
+
+        imp.general_inertial_scrolling_switch.connect_active_notify(
+            clone!(@weak self as settingspanel, @weak appwindow => move |switch| {
+                if !switch.is_active() {
+                    appwindow.overlays().dispatch_toast_text_singleton(
+                        &gettext("The app needs to be restarted."),
+                        0,
+                        &mut settingspanel.imp().app_restart_toast_singleton.borrow_mut()
+                    );
+                }
+            }),
+        );
     }
 
     fn setup_format(&self, appwindow: &RnAppWindow) {


### PR DESCRIPTION
this adds dispatching a toast whenever the inertial-scrolling option is toggled off.

I implemented it in the easiest way - only display a singleton text toast. From a UX standpoint it would probably be better to add a button toast that restarts the app when clicked, but I could not see an easy option to do that with `gtk::Application`. We could do that manually by adding some control flow in main. What do you think, is this enough?

I am also unsure about the toast text - if it should be passive like right now or if we should ask the user directly.
